### PR TITLE
Change userActivity responder

### DIFF
--- a/iOS 9 Search/DetailViewController.swift
+++ b/iOS 9 Search/DetailViewController.swift
@@ -48,7 +48,8 @@ class DetailViewController: UIViewController {
             attributeSet.title = detailItem.name
             attributeSet.contentDescription = detailItem.genre + "\n" + dateFormatter.stringFromDate(detailItem.time)
 
-            activity.becomeCurrent()
+            self.userActivity = activity
+            self.userActivity?.becomeCurrent()
         }
     }
 


### PR DESCRIPTION
Without specifying the `DetailViewController`'s `userActivity` object properties, or setting it as the current userActivity, the instantiated userActivity is released, and setting current doesn't retain it.

This assigns the `DetailViewController`'s `userActivity` to the otherwise correctly instantiated and configured `userActivity` (called `activity`), and sets the DVC's `userActivity` object as current.
